### PR TITLE
feat: remove footer links on NYT

### DIFF
--- a/src/extractors/custom/www.nytimes.com/index.js
+++ b/src/extractors/custom/www.nytimes.com/index.js
@@ -53,6 +53,7 @@ export const NYTimesExtractor = {
       '.comments',
       '.supplemental',
       '.nocontent',
+      '.story-footer-links',
     ],
   },
 


### PR DESCRIPTION
the links at the bottom of the stories feel a little spammy because of how we treat links vs. the way they are displayed on the Times, would like to clean them

<img width="749" alt="screen shot 2016-12-01 at 1 42 04 am" src="https://cloud.githubusercontent.com/assets/573182/20784376/d17b7df6-b767-11e6-8603-9879c35a0364.png">
