### PR TITLE
fix: womansay.net image urls

### DIFF
--- a/src/utils/dom/make-links-absolute.js
+++ b/src/utils/dom/make-links-absolute.js
@@ -8,13 +8,8 @@ function absolutize($, rootUrl, attr, $content) {
   $(`[${attr}]`, $content).each((_, node) => {
     const attrs = getAttrs(node);
     const url = attrs[attr];
-    let absoluteUrl = '';
+    const absoluteUrl = URL.resolve(baseUrl || rootUrl, url);
 
-    if (url && !baseUrl) {
-      absoluteUrl = URL.resolve(rootUrl, url);
-    } else {
-      absoluteUrl = URL.resolve(baseUrl, url);
-    }
     setAttr(node, attr, absoluteUrl);
   });
 }


### PR DESCRIPTION
This website uses the `base` tag to define their base URL `<base href="http://womansay.net/"/>`.
So I added a check for such cases so that the correct absolute URL is parsed.