### PR TITLE
docs: change text to include AMP and Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The Mercury Parser extracts the bits that humans care about from any URL you give it. That includes article content, titles, authors, published dates, excerpts, lead images, and more.
 
-The Mercury Parser module powers the [Mercury Parser AMP Converter](https://mercury.postlight.com/amp-converter/) and [Mercury Reader](https://mercury.postlight.com/reader/) a Chrome extension that puts all this information one click away.
+Mercury Parser powers the [Mercury AMP Converter](https://mercury.postlight.com/amp-converter/) and [Mercury Reader](https://mercury.postlight.com/reader/), a Chrome extension that removes ads and distractions, leaving only text and images for a beautiful reading view on any site.
 
 ## How? Like this.
 


### PR DESCRIPTION
Change the initial text to include mercury amp and reader instead of the parser-api
