### PR TITLE
docs: add hero to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Mercury Parser](https://13c27d41k2ud2vkddp226w55-wpengine.netdna-ssl.com/wp-content/uploads/2018/02/7bacd-16qwcaegges3hkrw70doz4w.png)
+
+
 # Mercury Parser - Extracting content from chaos
 
 [![CircleCI](https://circleci.com/gh/postlight/mercury-parser.svg?style=svg&circle-token=3026c2b527d3767750e767872d08991aeb4f8f10)](https://circleci.com/gh/postlight/mercury-parser) [![Build status](https://ci.appveyor.com/api/projects/status/bxwqp6mn8ijycqh4?svg=true)](https://ci.appveyor.com/project/adampash/mercury-parser) [![Apache License][license-apach-badge]][license-apach] [![MITC License][license-mit-badge]][license-mit]


### PR DESCRIPTION
Added a hero image to the README. (We may want to add the image itself to the repo, instead of reference it out on the web.)