### PR TITLE
feat: add mercury-parser cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const Mercury = require('./dist/mercury');
+
+const [, , url] = process.argv;
+
+(async urlToParse => {
+  if (!urlToParse) {
+    // eslint-disable-next-line no-multi-str
+    console.log(
+      '\n\
+mercury-parser\n\n\
+    The Mercury Parser extracts semantic content from any url\n\n\
+Usage:\n\
+\n\
+    mercury-parser [url-to-parse]\n\
+\n\
+'
+    );
+    return;
+  }
+  const result = await Mercury.parse(urlToParse);
+  console.log(JSON.stringify(result, null, 2));
+})(url);

--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
+/* eslint-disable no-multi-str */
+
 const Mercury = require('./dist/mercury');
 
 const [, , url] = process.argv;
 
 (async urlToParse => {
   if (!urlToParse) {
-    // eslint-disable-next-line no-multi-str
     console.log(
       '\n\
 mercury-parser\n\n\

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "content"
   ],
   "main": "./dist/mercury.js",
+  "bin": {
+    "mercury-parser": "./cli.js"
+  },
   "scripts": {
     "lint": "eslint . --fix",
     "lint:ci": "remark . && eslint .",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/mercury-parser/blob/master/CONTRIBUTING.md
-->

This PR adds a cli to the package so a user can run:

```bash
mercury-parser [url-to-parse]
```

And get a JSON response for the url passed.
