### PR TITLE
release: 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Mercury Parser Changelog
 
+### 2.0.0 (Feb 7, 2019)
+
+##### Commits
+
+yarn run v1.9.4
+\$ /Users/ap/code/postlight/labs/mercury-parser/node_modules/.bin/changelog-maker postlight mercury-parser
+
+- [[`e033835c72`](https://github.com/postlight/mercury-parser/commit/e033835c72)] - **fix**: parse signature in cli (#259) (Adam Pash)
+- [[`32748ad4c5`](https://github.com/postlight/mercury-parser/commit/32748ad4c5)] - **dx**: add .prettierignore (#258) (Adam Pash)
+- [[`2d0f10a888`](https://github.com/postlight/mercury-parser/commit/2d0f10a888)] - **dx**: add .prettierignore (#257) (Adam Pash)
+- [[`9b0664bc91`](https://github.com/postlight/mercury-parser/commit/9b0664bc91)] - **feat**: add content format output options (#256) (Adam Pash)
+- [[`a57f29eec3`](https://github.com/postlight/mercury-parser/commit/a57f29eec3)] - **release**: 1.1.1 (#254) (Adam Pash)
+
 ### 1.1.1 (Feb 7, 2019)
 
 ##### Commits

--- a/dist/mercury.js
+++ b/dist/mercury.js
@@ -4,6 +4,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var _regeneratorRuntime = _interopDefault(require('@babel/runtime-corejs2/regenerator'));
 var _objectSpread = _interopDefault(require('@babel/runtime-corejs2/helpers/objectSpread'));
+var _objectWithoutProperties = _interopDefault(require('@babel/runtime-corejs2/helpers/objectWithoutProperties'));
 var _asyncToGenerator = _interopDefault(require('@babel/runtime-corejs2/helpers/asyncToGenerator'));
 var URL = _interopDefault(require('url'));
 var cheerio = _interopDefault(require('cheerio'));
@@ -6429,8 +6430,10 @@ var Mercury = {
   parse: function () {
     var _parse = _asyncToGenerator(
     /*#__PURE__*/
-    _regeneratorRuntime.mark(function _callee(url, html) {
-      var opts,
+    _regeneratorRuntime.mark(function _callee(url) {
+      var _ref,
+          html,
+          opts,
           _opts$fetchAllPages,
           fetchAllPages,
           _opts$fallback,
@@ -6451,7 +6454,7 @@ var Mercury = {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
-              opts = _args.length > 2 && _args[2] !== undefined ? _args[2] : {};
+              _ref = _args.length > 1 && _args[1] !== undefined ? _args[1] : {}, html = _ref.html, opts = _objectWithoutProperties(_ref, ["html"]);
               _opts$fetchAllPages = opts.fetchAllPages, fetchAllPages = _opts$fetchAllPages === void 0 ? true : _opts$fetchAllPages, _opts$fallback = opts.fallback, fallback = _opts$fallback === void 0 ? true : _opts$fallback, _opts$contentType = opts.contentType, contentType = _opts$contentType === void 0 ? 'html' : _opts$contentType; // if no url was passed and this is the browser version,
               // set url to window.location.href and load the html
               // from the current page
@@ -6549,7 +6552,7 @@ var Mercury = {
       }, _callee, this);
     }));
 
-    function parse(_x, _x2) {
+    function parse(_x) {
       return _parse.apply(this, arguments);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postlight/mercury-parser",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Mercury transforms web pages into clean text. Publishers and programmers use it to make the web make sense, and readers use it to read any web article comfortably.",
   "author": "Postlight <mercury@postlight.com>",
   "homepage": "https://mercury.postlight.com",


### PR DESCRIPTION
This release includes a breaking change to the signature of the `Mercury.parse` function.

Before:

```javascript
Mercury.parse(url, html, opts);
```

After

```javascript
Mercury.parse(url, opts); // html is included in opts
```

The `url, html` signature was there for a long time before I started adding options, but in the end `html` is just another optional argument, and should be treated as such. Otherwise you end up with `Mercury.parse(url, null, { foo: 'bar' })` when you want to pass an option but don't want to pass `html`, which isn't the best experience. This will result in a major version bump.