### PR TITLE
fix: jquery doesn't like the case insensitive meta content selector

### DIFF
--- a/src/resource/index.js
+++ b/src/resource/index.js
@@ -66,8 +66,11 @@ const Resource = {
     let $ = cheerio.load(decodedContent);
 
     // after first cheerio.load, check to see if encoding matches
+    const contentTypeSelector = cheerio.browser
+      ? 'meta[http-equiv=content-type]'
+      : 'meta[http-equiv=content-type i]';
     const metaContentType =
-      $('meta[http-equiv=content-type i]').attr('content') ||
+      $(contentTypeSelector).attr('content') ||
       $('meta[charset]').attr('charset');
     const properEncoding = getEncoding(metaContentType);
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/mercury-parser/blob/master/CONTRIBUTING.md
-->

For now just reverting to original for browser. 
