### PR TITLE
fix: Preserve whitespace in certain HTML elements

### DIFF
--- a/src/utils/text/fixtures/html.js
+++ b/src/utils/text/fixtures/html.js
@@ -610,6 +610,16 @@ const HTML = {
     `,
     after: 'What do you think?',
   },
+  normalizeSpacesPreserve: {
+    before: `
+      <div>
+        <p>What   do  you    think?</p>
+        <pre>  What     happens to        spaces?    </pre>
+      </div>
+    `,
+    after:
+      '<div> <p>What do you think?</p> <pre>  What     happens to        spaces?    </pre> </div>',
+  },
 
   // cleanHeaders
   cleanFirstHeds: {

--- a/src/utils/text/normalize-spaces.js
+++ b/src/utils/text/normalize-spaces.js
@@ -1,4 +1,4 @@
-const NORMALIZE_RE = /\s{2,}/g;
+const NORMALIZE_RE = /\s{2,}(?![^<>]*<\/(pre|code|textarea)>)/g;
 
 export default function normalizeSpaces(text) {
   return text.replace(NORMALIZE_RE, ' ').trim();

--- a/src/utils/text/normalize-spaces.test.js
+++ b/src/utils/text/normalize-spaces.test.js
@@ -16,4 +16,11 @@ describe('normalizeSpaces(text)', () => {
     );
     assert.equal(result, HTML.normalizeSpaces.after);
   });
+
+  it('preserves spaces in preformatted text blocks', () => {
+    const $ = cheerio.load(HTML.normalizeSpacesPreserve.before);
+
+    const result = normalizeSpaces($.html());
+    assert.equal(result, HTML.normalizeSpacesPreserve.after);
+  });
 });


### PR DESCRIPTION
Addresses #310 

Preserve whitespace in the the following HTML elements:
- `<code>`
- `<pre>`
- `<textarea>`