### PR TITLE
fix: Explicity reject non-200 status codes

### DIFF
--- a/src/mercury.test.js
+++ b/src/mercury.test.js
@@ -32,12 +32,12 @@ describe('Mercury', () => {
       assert.equal(result.content.indexOf('score="') === -1, true);
     });
 
-    it('returns an error on non-2xx responses', async () => {
+    it('returns an error on non-200 responses', async () => {
       const error = await Mercury.parse(
         'https://www.thekitchn.com/instant-pot-chicken-pesto-pasta-eating-instantly-267141'
       );
 
-      assert(/instructed to reject non-2xx/i.test(error.message));
+      assert(/instructed to reject non-200/i.test(error.message));
     });
 
     it('returns an error on invalid content types', async () => {

--- a/src/resource/index.test.js
+++ b/src/resource/index.test.js
@@ -22,7 +22,7 @@ describe('Resource', () => {
       const url = 'http://nytimes.com/500';
       const error = await Resource.create(url);
 
-      assert(/instructed to reject non-2xx/i.test(error.message));
+      assert(/instructed to reject non-200/i.test(error.message));
     });
 
     it('fetches with different encoding on body', async () => {

--- a/src/resource/utils/fetch-resource.js
+++ b/src/resource/utils/fetch-resource.js
@@ -21,11 +21,11 @@ function get(options) {
 }
 
 // Evaluate a response to ensure it's something we should be keeping.
-// This does not validate in the sense of a response being 200 level or
-// not. Validation here means that we haven't found reason to bail from
+// This does not validate in the sense of a response being 200 or not.
+// Validation here means that we haven't found reason to bail from
 // further processing of this url.
 
-export function validateResponse(response, parseNon2xx = false) {
+export function validateResponse(response, parseNon200 = false) {
   // Check if we got a valid status code
   // This isn't great, but I'm requiring a statusMessage to be set
   // before short circuiting b/c nock doesn't set it in tests
@@ -40,11 +40,11 @@ export function validateResponse(response, parseNon2xx = false) {
       throw new Error(
         `Unable to fetch content. Original exception was ${response.error}`
       );
-    } else if (!parseNon2xx) {
+    } else if (!parseNon200) {
       throw new Error(
         `Resource returned a response status code of ${
           response.statusCode
-        } and resource was instructed to reject non-2xx level status codes.`
+        } and resource was instructed to reject non-200 status codes.`
       );
     }
   }

--- a/src/resource/utils/fetch-resource.test.js
+++ b/src/resource/utils/fetch-resource.test.js
@@ -95,14 +95,14 @@ describe('validateResponse(response)', () => {
     }, /unable to fetch content/i);
   });
 
-  it('throws an error if response code is not 2xx', () => {
+  it('throws an error if response code is not 200', () => {
     const invalidResponse = {
       statusCode: 500,
     };
 
     assert.throws(() => {
       validateResponse(invalidResponse);
-    }, /instructed to reject non-2xx/i);
+    }, /instructed to reject non-200/i);
   });
 
   it('throws an error if response has bad content-type', () => {


### PR DESCRIPTION
Indicate that non-200 status codes are rejected, as opposed to "non-2xx".

In terms of HTTP GET requests for content on the web, the status code that makes most sense as a response containing content that would eventually be parseable by Mercury is 200, the other 2xx level status codes are more suited for API requests, and typically contain different kinds of content in the responses, e.g. 204 indicates "No Content", 206 indicates "Partial Content", etc...

The 202 status code, while in fact used to indicate that the request has been "Accepted", is used to indicate that the processing for the request has not been completed, and is expected to contain:
>the request's current status and point to (or embed) a status monitor that can provide the user with an estimate of when the request will be fulfilled

as opposed to the actual content. (Addresses #279)