### PR TITLE
fix: Initialize Content-Type as empty string if not present

### DIFF
--- a/src/resource/index.js
+++ b/src/resource/index.js
@@ -40,7 +40,7 @@ const Resource = {
   },
 
   generateDoc({ body: content, response }) {
-    const { 'content-type': contentType } = response.headers;
+    const { 'content-type': contentType = '' } = response.headers;
 
     // TODO: Implement is_text function from
     // https://github.com/ReadabilityHoldings/readability/blob/8dc89613241d04741ebd42fa9fa7df1b1d746303/readability/utils/text.py#L57

--- a/src/resource/index.test.js
+++ b/src/resource/index.test.js
@@ -97,6 +97,25 @@ describe('Resource', () => {
       }, /content does not appear to be text/i);
     });
 
+    it('throws an error if the response has no Content-Type header', () => {
+      const response = {
+        headers: {},
+      };
+      const body = '';
+
+      // This assertion is more elaborate than the others to be sure that we're
+      // throwing an `Error` and not raising a runtime exception.
+      assert.throws(
+        () => {
+          Resource.generateDoc({ body, response });
+        },
+        err => (
+          (err instanceof Error) &&
+          /content does not appear to be text/i.test(err)
+        )
+      );
+    });
+
     it('throws an error if the content has no children', () => {
       // jquery's parser won't work this way, and this is
       // an outside case


### PR DESCRIPTION
(This is a re-creation of #179; I did something weird with my fork 🍴)

This may be exceedingly rare, but if the response does not include a
Content-Type header, the parser will raise an exception. This fix ensures that
even if the header is not present, the value we check is still a string.

I discovered this issue while trying to parse my own site, and while I've fixed
the headers there, I left one bad URL for verification:
https://johnholdun.com/404
