### PR TITLE
fix: skip absolutizing empty hrefs

### DIFF
--- a/src/utils/dom/make-links-absolute.js
+++ b/src/utils/dom/make-links-absolute.js
@@ -8,6 +8,7 @@ function absolutize($, rootUrl, attr) {
   $(`[${attr}]`).each((_, node) => {
     const attrs = getAttrs(node);
     const url = attrs[attr];
+    if (!url) return;
     const absoluteUrl = URL.resolve(baseUrl || rootUrl, url);
 
     setAttr(node, attr, absoluteUrl);


### PR DESCRIPTION
Don't attempt to transform empty `href` and `src` attributes into absolute URLs.

This was breaking the web build tests since both CNN URLs used for the tests (http://www.cnn.com/2016/11/05/middleeast/iraq-mosul-isis-offensive/ and https://www.cnn.com/2019/01/30/politics/trump-intel-chiefs-foreign-policy-iran-isis-north-korea/index.html) contain the following tag in the document `head`
```html
<link rel="dns-prefetch" href="" />
```