### PR TITLE
fix: skip absolutizing invalid srcsets

### DIFF
--- a/src/utils/dom/make-links-absolute.js
+++ b/src/utils/dom/make-links-absolute.js
@@ -27,6 +27,7 @@ function absolutizeSet($, rootUrl, $content) {
       const candidates = urlSet.match(
         /(?:\s*)(\S+(?:\s*[\d.]+[wx])?)(?:\s*,\s*)?/g
       );
+      if (!candidates) return;
       const absoluteCandidates = candidates.map(candidate => {
         // a candidate URL cannot start or end with a comma
         // descriptors are separated from the URLs by unescaped whitespace

--- a/src/utils/dom/make-links-absolute.test.js
+++ b/src/utils/dom/make-links-absolute.test.js
@@ -108,6 +108,33 @@ describe('makeLinksAbsolute($)', () => {
       );
     });
 
+    it('does nothing when the srcset is empty or just whitespace', () => {
+      const html = `<div>
+        <picture>
+          <source srcset="" media="(max-width: 450px)">
+          <source srcset=" ">
+          <img src="http://example.com/assets/images/rhythm/076.jpg" alt="Vertical and horizontal rhythm">
+        </picture>
+      </div>`;
+      const $ = cheerio.load(html);
+      const $content = $('*').first();
+
+      const result = $.html(
+        makeLinksAbsolute($content, $, 'http://example.com')
+      );
+
+      assert.equal(
+        result,
+        `<div>
+        <picture>
+          <source srcset="" media="(max-width: 450px)">
+          <source srcset=" ">
+          <img src="http://example.com/assets/images/rhythm/076.jpg" alt="Vertical and horizontal rhythm">
+        </picture>
+      </div>`
+      );
+    });
+
     it('handles comma separated (with whitespace) srcset files with device-pixel-ratio descriptors', () => {
       const html = `<div>
         <picture>


### PR DESCRIPTION
Skip attempting to absolutize empty or invalid `srcset` attributes..

Addresses #385 