### PR TITLE
feat: Allows to add custom extractor by API (resolve: #397)

### DIFF
--- a/src/extractors/custom/README.md
+++ b/src/extractors/custom/README.md
@@ -11,7 +11,7 @@ import Mercury from '@postlight/mercury-parser';
 //...
 import ExampleComExtractor from './ExampleComExtractor';
 
-Mercury.add(ExampleComExtractor);
+Mercury.addExtractor(ExampleComExtractor);
 
 //...
 

--- a/src/extractors/custom/README.md
+++ b/src/extractors/custom/README.md
@@ -2,6 +2,22 @@
 
 Mercury can extract meaningful content from almost any web site, but custom parsers/extractors allow the Mercury Parser to find the content more quickly and more accurately than it might otherwise do. Our goal is to include custom parsers as many sites as we can, and we'd love your help!
 
+## Runtime extractors
+
+Mercury can obtain extractor with API in runtime.
+
+```javascript
+import Mercury from '@postlight/mercury-parser';
+//...
+import ExampleComExtractor from './ExampleComExtractor';
+
+Mercury.add(ExampleComExtractor);
+
+//...
+
+Mercury.parse('www.example.com').then(result => console.log(result));
+```
+
 ## The basics of parsing a site with a custom parser
 
 Custom parsers allow you to write CSS selectors that will find the content you're looking for on the page you're testing against. If you've written any CSS or jQuery, CSS selectors should be very familiar to you.

--- a/src/extractors/get-extractor.js
+++ b/src/extractors/get-extractor.js
@@ -1,8 +1,11 @@
 import URL from 'url';
 
+import mergeSupportedDomains from '../utils/merge-supported-domains';
 import Extractors from './all';
 import GenericExtractor from './generic';
 import detectByHtml from './detect-by-html';
+
+const apiExtractors = {};
 
 export default function getExtractor(url, parsedUrl, $) {
   parsedUrl = parsedUrl || URL.parse(url);
@@ -13,9 +16,15 @@ export default function getExtractor(url, parsedUrl, $) {
     .join('.');
 
   return (
+    apiExtractors[hostname] ||
+    apiExtractors[baseDomain] ||
     Extractors[hostname] ||
     Extractors[baseDomain] ||
     detectByHtml($) ||
     GenericExtractor
   );
+}
+
+export function addExtractor(extractor) {
+  if (extractor) Object.assign(apiExtractors, mergeSupportedDomains(extractor));
 }

--- a/src/mercury.js
+++ b/src/mercury.js
@@ -4,7 +4,7 @@ import TurndownService from 'turndown';
 
 import Resource from 'resource';
 import { validateUrl } from 'utils';
-import getExtractor from 'extractors/get-extractor';
+import getExtractor, { addExtractor } from 'extractors/get-extractor';
 import RootExtractor, { selectExtendedTypes } from 'extractors/root-extractor';
 import collectAllPages from 'extractors/collect-all-pages';
 
@@ -104,7 +104,7 @@ const Mercury = {
 
     return { ...result, ...extendedTypes };
   },
-
+  addExtractor,
   browser: !!cheerio.browser,
 
   // A convenience method for getting a resource


### PR DESCRIPTION
Allows to add custom extractor by API, for example :
```javascript
import Mercury from '@postlight/mercury-parser';
import ExampleExtractor from './ExampleExtractor';

Mercury.add(ExampleExtractor);
Mercury.parse("www.example.com").then(result => console.log(result));
```