### PR TITLE
Improve parser to accept postman-request options

### DIFF
--- a/src/mercury.js
+++ b/src/mercury.js
@@ -9,15 +9,18 @@ import RootExtractor, { selectExtendedTypes } from 'extractors/root-extractor';
 import collectAllPages from 'extractors/collect-all-pages';
 
 const Mercury = {
-  async parse(url, { html, ...opts } = {}) {
-    const {
+  async parse(
+    url,
+    {
+      html,
       fetchAllPages = true,
       fallback = true,
       contentType = 'html',
       headers = {},
       extend,
-    } = opts;
-
+      fetchOptions = {},
+    } = {}
+  ) {
     // if no url was passed and this is the browser version,
     // set url to window.location.href and load the html
     // from the current page
@@ -36,7 +39,13 @@ const Mercury = {
       };
     }
 
-    const $ = await Resource.create(url, html, parsedUrl, headers);
+    const $ = await Resource.create(
+      url,
+      html,
+      parsedUrl,
+      headers,
+      fetchOptions
+    );
 
     // If we found an error creating the resource, return that error
     if ($.failed) {

--- a/src/resource/index.js
+++ b/src/resource/index.js
@@ -13,7 +13,14 @@ const Resource = {
   //                  attempting to fetch it ourselves. Expects a
   //                  string.
   // :param headers: Custom headers to be included in the request
-  async create(url, preparedResponse, parsedUrl, headers = {}) {
+  // :param fetchOptions: Fetch options
+  async create(
+    url,
+    preparedResponse,
+    parsedUrl,
+    headers = {},
+    fetchOptions = {}
+  ) {
     let result;
 
     if (preparedResponse) {
@@ -28,7 +35,7 @@ const Resource = {
 
       result = { body: preparedResponse, response: validResponse };
     } else {
-      result = await fetchResource(url, parsedUrl, headers);
+      result = await fetchResource(url, parsedUrl, headers, fetchOptions);
     }
 
     if (result.error) {

--- a/src/resource/utils/fetch-resource.js
+++ b/src/resource/utils/fetch-resource.js
@@ -86,7 +86,12 @@ export function baseDomain({ host }) {
 // TODO: Ensure we are not fetching something enormous. Always return
 //       unicode content for HTML, with charset conversion.
 
-export default async function fetchResource(url, parsedUrl, headers = {}) {
+export default async function fetchResource(
+  url,
+  parsedUrl,
+  headers = {},
+  fetchOptions = {}
+) {
   parsedUrl = parsedUrl || URL.parse(encodeURI(url));
   const options = {
     url: parsedUrl.href,
@@ -107,6 +112,7 @@ export default async function fetchResource(url, parsedUrl, headers = {}) {
           // Follow GET redirects; this option is for Node only
           followRedirect: true,
         }),
+    ...fetchOptions,
   };
 
   const { response, body } = await get(options);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/mercury-parser/blob/master/CONTRIBUTING.md
-->

# Improvement Rationale

I am using `mercury-parser` to extract content of RSS feed articles, but my scraping script failed to extract some articles because SSL certificate of article's website was expired or invalid.

After reviewing the source code of `mercury-parser`, I found that it was using `postman-request`, which supports `strictSSL` flag in fetch options.

By setting `strictSSL` to `false`, my scraping script was able to successfully scrape the content.

So, I updated `mercury-parser` to accept fetch options of `mercury-parser` to make consumers able to fully utilize `postman-request` under the hood.
