### PR TITLE
fix: don't try to re-decode prepared response

### DIFF
--- a/src/resource/index.test.js
+++ b/src/resource/index.test.js
@@ -78,6 +78,17 @@ describe('Resource', () => {
       assert.equal(badEncodingRe.test($.html()), false);
       assert.equal(typeof $, 'function');
     });
+
+    it('doesnt mangle non-ascii characters in prefetched response', async () => {
+      const url = 'https://www.gruene.de/themen/digitalisierung';
+      const prefetched =
+        '<!DOCTYPE html><html lang="de"><head><meta charSet="UTF-8"/><meta http-equiv="x-ua-compatible" content="ie=edge"/><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/></head><body><div id="___gatsby"><h1 class="styles-module--headline--niWjO">Wir gestalten die Digitalisierung</h1><p>Wir Grüne kämpfen für ein offenes, gemeinwohlorientiertes Netz. Wir wollen den digitalen Wandel gerecht gestalten und setzen uns für Verantwortung, Freiheit und Recht im Netz ein. Netzpolitik und Digitalisierung sind zentrale politische Querschnittsaufgaben für eine moderne Gesellschaft. Im Mittelpunkt stehen für uns eine zukunftsfähige digitale Infrastruktur, der freie und gleichberechtigte Zugang zum Netz für alle, der Schutz unserer Privatsphäre und persönlichen Daten, sowie eine modernisierte  Verwaltung.</p></div></body></html>';
+
+      const $ = await Resource.create(url, prefetched);
+      console.log($.html());
+      assert.equal(/Gr&#xFC;ne/.test($.html()), true);
+      assert.equal(/&#xFFFD;/.test($.html()), false);
+    });
   });
 
   describe('generateDoc({ body, response })', () => {

--- a/src/resource/index.test.js
+++ b/src/resource/index.test.js
@@ -85,7 +85,6 @@ describe('Resource', () => {
         '<!DOCTYPE html><html lang="de"><head><meta charSet="UTF-8"/><meta http-equiv="x-ua-compatible" content="ie=edge"/><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/></head><body><div id="___gatsby"><h1 class="styles-module--headline--niWjO">Wir gestalten die Digitalisierung</h1><p>Wir Grüne kämpfen für ein offenes, gemeinwohlorientiertes Netz. Wir wollen den digitalen Wandel gerecht gestalten und setzen uns für Verantwortung, Freiheit und Recht im Netz ein. Netzpolitik und Digitalisierung sind zentrale politische Querschnittsaufgaben für eine moderne Gesellschaft. Im Mittelpunkt stehen für uns eine zukunftsfähige digitale Infrastruktur, der freie und gleichberechtigte Zugang zum Netz für alle, der Schutz unserer Privatsphäre und persönlichen Daten, sowie eine modernisierte  Verwaltung.</p></div></body></html>';
 
       const $ = await Resource.create(url, prefetched);
-      console.log($.html());
       assert.equal(/Gr&#xFC;ne/.test($.html()), true);
       assert.equal(/&#xFFFD;/.test($.html()), false);
     });


### PR DESCRIPTION
Fixes #490 (I think!) and adds a test case for the bug that fails on `master`.

https://github.com/ashtuchkin/iconv-lite/wiki/Use-Buffers-when-decoding#solution says "In general, keep in mind that all javascript strings are already decoded and should not be decoded again."

Per that note, I think the charset-detection logic in `encodeDoc` should be skipped entirely when using a `preparedResponse`, to prevent double-decoding the html string.  Instead we should assume that the caller has already decoded the content when a `preparedResponse` has been provided.