### PR TITLE
Feature Request: Support an ES Modules Dist Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "build": "yarn lint && rollup -c && yarn test:build",
     "build:ci": "rollup -c && yarn test:build",
     "build:web": "yarn lint && rollup -c rollup.config.web.js && yarn test:build:web",
+    "build:esm": "yarn lint && rollup -c rollup.config.esm.js && yarn test:build:esm",
+    "build:esm:ci": "rollup -c rollup.config.esm.js && yarn test:build:esm",
     "build:web:ci": "rollup -c rollup.config.web.js && yarn test:build:web",
     "release": "yarn build && yarn build:web",
     "build:generator": "rollup -c scripts/rollup.config.js",
@@ -44,6 +46,7 @@
     "test:web": "node ./node_modules/karma/bin/karma start karma.conf.js --auto-watch",
     "test:build": "cd ./scripts && jest check-build.test.js",
     "test:build:web": "node ./scripts/proxy-browser-test.js",
+    "test:build:esm": "node ./scripts/proxy-browser-test.js",
     "watch:test": "jest --watch",
     "generate-parser": "node ./dist/generate-custom-parser.js"
   },
@@ -104,6 +107,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-terser": "^6.1.0",
     "rollup-plugin-uglify": "^6.0.1",
     "watchify": "^3.11.1"
   },

--- a/rollup.config.esm.js
+++ b/rollup.config.esm.js
@@ -1,0 +1,32 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import globals from 'rollup-plugin-node-globals';
+import { terser } from 'rollup-plugin-terser'; // eslint-disable-line import/extensions
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  input: 'src/mercury.js',
+  plugins: [
+    babel({
+      runtimeHelpers: true,
+      exclude: './node_modules#<{(|*',
+    }),
+    commonjs({
+      ignoreGlobal: true,
+    }),
+    globals(),
+    nodeResolve({
+      browser: true,
+      preferBuiltins: false,
+    }),
+    terser(),
+  ],
+  treeshake: true,
+  output: {
+    file: process.env.MERCURY_TEST_BUILD
+      ? 'dist/mercury_test.esm.js'
+      : 'dist/mercury.esm.js',
+    format: 'es',
+    sourceMap: true,
+  },
+};


### PR DESCRIPTION
Today, if you want to user mercury in the browser, you can pull it in via a `<script>` tag from [a CDN like unpkg](https://unpkg.com/browse/@postlight/mercury-parser@2.2.0/dist/) as an iife.

```html
<script src="https://unpkg.com/@postlight/mercury-parser@2.2.0/dist/mercury.web.js"></script>
```

Would be nice if there was an ES modules build, so then you could import it directly:

```js
import Mercury from "https://unpkg.com/@postlight/mercury-parser@2.3.0/dist/mercury.esm.js"
```

It seems like this would be pretty straightforward. I'm not entirely sure how the build is set up, but mimicking what I saw with the `build:web` scripts, I added one for ES Modules. Tested locally and it produced a build file (`dist/mercury.esm.js`) which I could import myself in a local project.

Note: I had to use `terser` instead of `uglify` for ES modules. [See this issue](https://github.com/TrySound/rollup-plugin-uglify/issues/36#issuecomment-418189796).