### PR TITLE
chore: remove greenkeeper configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,17 +157,5 @@
       "prettier --write",
       "git add"
     ]
-  },
-  "greenkeeper": {
-    "ignore": [
-      "jasmine-core",
-      "karma-jasmine",
-      "rollup-plugin-node-resolve",
-      "eslint-import-resolver-babel-module",
-      "jest",
-      "jest-cli",
-      "babel-jest",
-      "karma"
-    ]
   }
 }


### PR DESCRIPTION
Greenkeeper stopped their services in June and migrated to [synk](https://snyk.io/)

This PR clears any configs related to greenkeeper and we can continue using depandabot.