### PR TITLE
feat: Add date formats to two extractors

### DIFF
--- a/src/extractors/custom/ici.radio-canada.ca/index.js
+++ b/src/extractors/custom/ici.radio-canada.ca/index.js
@@ -11,7 +11,7 @@ export const IciRadioCanadaCaExtractor = {
 
   date_published: {
     selectors: [['meta[name="dc.date.created"]', 'value']],
-
+    format: 'YYYY-MM-DD|HH[h]mm',
     timezone: 'America/New_York',
   },
 

--- a/src/extractors/custom/www.dmagazine.com/index.js
+++ b/src/extractors/custom/www.dmagazine.com/index.js
@@ -16,6 +16,7 @@ export const WwwDmagazineComExtractor = {
     ],
 
     timezone: 'America/Chicago',
+    format: 'MMMM D, YYYY h:mm a',
   },
 
   dek: {


### PR DESCRIPTION
These extractors were variously failing tests as I tried updating dependencies. It seems like some of the format detection logic has changed, and making these date detectors more explicit fixes them.

As long as the tests for these extractors continue to pass, we should be good to merge this commit. Then #656 should turn green as well.