### PR TITLE
Fix cli.js ignoring `--version` flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -107,5 +107,6 @@ Usage:\n\
   extend || e,
   extendList || l,
   header || h,
-  addExtractor || x
+  addExtractor || x,
+  version,
 );


### PR DESCRIPTION
Fixes issue with `--version` flag mentioned here: https://github.com/postlight/parser/pull/610#issuecomment-1772072583

This is needed for ArchiveBox (and many other UNIX tools) to autodetect the version.