### PR TITLE
deps: updates direct and transitive vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "string-direction": "^0.1.2",
     "turndown": "^7.1.1",
     "valid-url": "^1.0.9",
-    "wuzzy": "^0.1.4",
+    "wuzzy": "^0.1.8",
     "yargs-parser": "^15.0.1"
   },
   "bundleDependencies": [
@@ -161,5 +161,9 @@
       "prettier --write",
       "git add"
     ]
+  },
+  "resolutions": {
+    "nth-check": "^2.0.1",
+    "css-what": "2.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,9 +1620,10 @@ body-parser@^1.19.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-boolbase@~1.0.0:
+boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2518,9 +2519,10 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-what@2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+css-what@2.1, css-what@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.8"
@@ -6374,11 +6376,12 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nth-check@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+nth-check@^2.0.1, nth-check@~1.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
-    boolbase "~1.0.0"
+    boolbase "^1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -9325,10 +9328,10 @@ ws@~8.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
   integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
-wuzzy@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/wuzzy/-/wuzzy-0.1.4.tgz#f2ea42c5c5a216ef7dc68158356a7d5f84432102"
-  integrity sha512-0I20vx7xWb+fZ1XKw54EhZukVsH3rRKnwtdu+MCb2nHITeypPZRr9Y1VOFdeZu48YvzxO33ReKoyIP5IG+WaOw==
+wuzzy@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/wuzzy/-/wuzzy-0.1.8.tgz#2e729f157b5757d4ed4d73c050f9f4ae12336f5c"
+  integrity sha512-FUzKQepFSTnANsDYwxpIzGJ/dIJaqxuMre6tzzbvWwFAiUHPsI1nVQVCLK4Xqr67KO7oYAK0kaCcI/+WYj/7JA==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
- Updates transitive dep `nth-check` from 1.0.2 to ^2.0.1 to address [Regular Expression Denial of Service (ReDoS) vulnerability](https://security.snyk.io/vuln/SNYK-JS-NTHCHECK-1586032)
- Updates transitive dep `css-what` from 2.1.0 to 2.1.3 to fix [Regular Expression Denial of Service (ReDoS)](https://security.snyk.io/vuln/SNYK-JS-CSSWHAT-3035488)
- Updates direct dep `wuzzy` from ^0.1.4 to ^0.1.8 to address [GPL-3.0 license](https://snyk.io/vuln/snyk:lic:npm:wuzzy:GPL-3.0)

NB: The security team was notified via email as per the [contribution docs](https://github.com/postlight/parser/blob/main/CONTRIBUTING.md#security) but no acknowledgement was received. It was followed up by another email to [mercury@postlight.com](mailto:mercury@postlight.com) with no acknowledgement again. Hence this PR to fix the vulnerabilities.

<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/parser/blob/master/CONTRIBUTING.md
-->
